### PR TITLE
SMap addition was wrong:

### DIFF
--- a/Flips.Tests/Scalar.fs
+++ b/Flips.Tests/Scalar.fs
@@ -1,4 +1,5 @@
-﻿namespace Flips.Tests
+﻿#nowarn "1240" // This type test or downcast will ignore the unit-of-measure ''Measure'
+namespace Flips.Tests
 
 [<CustomEquality; CustomComparison>]
 type Scalar = Value of float with

--- a/Flips.Tests/Scalar.fs
+++ b/Flips.Tests/Scalar.fs
@@ -63,3 +63,70 @@ type Scalar = Value of float with
             match yObj with
             | :? Scalar as s -> compare this s
             | _ -> invalidArg "yObj" "Cannot compare values of different types"
+
+namespace Flips.Tests.UnitsOfMeasure
+[<CustomEquality; CustomComparison>]
+type Scalar<[<Measure>] 'Measure> = Value of float<'Measure> with
+
+    static member private NearlyEquals (Value a:Scalar<'Measure>) (Value b:Scalar<'Measure>) : bool =
+        let aValue = System.BitConverter.DoubleToInt64Bits (float a)
+        let bValue = System.BitConverter.DoubleToInt64Bits (float b)
+        if (aValue >>> 63) <> (bValue >>> 63) then
+            a = b
+        else
+            System.Math.Abs(aValue - bValue) <= 10_000L
+
+    static member (+) (Value lhs:Scalar<'Measure>, Value rhs:Scalar<'Measure>) =
+        Value (lhs + rhs)
+        
+    static member (+) (Value s:Scalar<'Measure>, f:float<'Measure>) =
+        Value (s + f)
+
+    static member (+) (f:float<'Measure>, Value s:Scalar<'Measure>) =
+        Value (s + f)
+
+    static member (*) (Value lhs:Scalar<'Measure>, Value rhs:Scalar<'Measure>) =
+        Value (lhs * rhs)
+
+    static member (*) (Value s:Scalar<'Measure>, f:float) =
+        Value (s * f)
+
+    static member (*) (f:float, Value s:Scalar<'Measure>) =
+        Value (s * f)
+
+    static member (-) (Value lhs:Scalar<'Measure>, Value rhs:Scalar<'Measure>) =
+        Value (lhs - rhs)
+
+    static member (-) (Value s:Scalar<'Measure>, f:float<'Measure>) =
+        Value (s - f)
+
+    static member (-) (f:float<'Measure>, Value s:Scalar<'Measure>) =
+        Value (f - s)
+
+    static member (/) (Value lhs:Scalar<'Measure>, Value rhs:Scalar<'Measure>) =
+        Value (lhs / rhs)
+
+    static member (/) (f:float<'Measure>, Value s:Scalar<'Measure>) =
+        Value (f / s)
+
+    static member (/) (Value s:Scalar<'Measure>, f:float<'Measure>) =
+        Value (s / f)
+
+    static member Zero = Value 0.0
+
+    override this.GetHashCode () =
+        let (Value v) = this
+        hash v
+
+    override this.Equals(obj) =
+        match obj with
+        | :? Scalar<'Measure> as s -> Scalar<'Measure>.NearlyEquals this s 
+        | _ -> false
+
+    interface System.IComparable with
+        member this.CompareTo yObj =
+            match yObj with
+            | :? Scalar<'Measure> as s -> compare this s
+            | _ -> invalidArg "yObj" "Cannot compare values of different types"
+
+

--- a/Flips.Tests/Tests.fs
+++ b/Flips.Tests/Tests.fs
@@ -555,6 +555,24 @@ module Types =
             let r1 = (s1 + s2) + s3
             let r2 = s1 + (s2 + s3)
             Assert.StrictEqual(r1, r2)
+    
+        [<Property>]
+        let ``SliceMap addition is pairwise sum`` (v1:List<(NonEmptyString * Scalar)>) (v2:List<(NonEmptyString * Scalar)>) =
+            let s1 = Map.ofList v1 |> SMap
+            let s2 = Map.ofList v2 |> SMap
+            
+            let r1 = s1 + s2
+            let r2 =
+              [
+                for key in s1.Keys + s2.Keys do
+                  match s1.TryFind key, s2.TryFind key with
+                  | Some v1, Some v2 -> key, v1 + v2
+                  | None, Some v1 | Some v1, None -> key, v1
+                  | _ -> key, Value 0.
+              ]
+              |> SMap.ofList
+
+            Assert.StrictEqual(r1, r2)
 
         [<Property>]
         let ``SliceMap element-wise multiplication is commutative`` (v1:List<(NonEmptyString * Scalar)>) (v2:List<(NonEmptyString * Scalar)>) =

--- a/Flips.Tests/UnitsOfMeasure.Tests.fs
+++ b/Flips.Tests/UnitsOfMeasure.Tests.fs
@@ -208,30 +208,37 @@ module UnitsOfMeasureTests =
             let r = expr + d - d
             Assert.Equal(expr, r)
 
-
+    [<Properties(Arbitrary = [| typeof<UnitsOfMeasure.UnitOfMeasureTypes>; typeof<Types> |] )>]
+    module SMaps =
         // just make sure it compiles (was buggy giving SMap<NonEmptyString, Scalar<Item ^ 2>> due to implementation issue, same for SMap2, SMap3, SMap4 and SMap5)
         [<Property>]
-        let ``SMap pairwise addition doesn't affect measure type `` (a: SMap<NonEmptyString,Scalar<Item>>) (b: SMap<NonEmptyString,Scalar<Item>>) =
+        let ``SMap pairwise addition doesn't affect measure type `` (a: List<NonEmptyString*Scalar<Item>>) (b: List<NonEmptyString*Scalar<Item>>) =
+          let a = SMap.ofList a
+          let b = SMap.ofList b
           let c : SMap<NonEmptyString, Scalar<Item>> = a + b
           ()
         [<Property>]
-        let ``SMap2 pairwise addition doesn't affect measure type `` (a: SMap2<NonEmptyString,NonEmptyString,Scalar<Item>>) (b: SMap2<NonEmptyString,NonEmptyString,Scalar<Item>>) =
-          // just make sure it compiles (was buggy giving SMap<NonEmptyString, Scalar<Item ^ 2>> due to implementation issue)
+        let ``SMap2 pairwise addition doesn't affect measure type `` (a: List<(NonEmptyString*NonEmptyString)*Scalar<Item>>) (b: List<(NonEmptyString*NonEmptyString)*Scalar<Item>>) =
+          let a = SMap2.ofList a
+          let b = SMap2.ofList b
           let c : SMap2<NonEmptyString, NonEmptyString, Scalar<Item>> = a + b
           ()
         [<Property>]
-        let ``SMap3 pairwise addition doesn't affect measure type `` (a: SMap3<NonEmptyString,NonEmptyString,NonEmptyString,Scalar<Item>>) (b: SMap3<NonEmptyString,NonEmptyString,NonEmptyString,Scalar<Item>>) =
-          // just make sure it compiles (was buggy giving SMap<NonEmptyString, Scalar<Item ^ 2>> due to implementation issue)
+        let ``SMap3 pairwise addition doesn't affect measure type `` (a: List<(NonEmptyString*NonEmptyString*NonEmptyString)*Scalar<Item>>) (b: List<(NonEmptyString*NonEmptyString*NonEmptyString)*Scalar<Item>>) =
+          let a = SMap3.ofList a
+          let b = SMap3.ofList b
           let c : SMap3<NonEmptyString,NonEmptyString,NonEmptyString, Scalar<Item>> = a + b
           ()
         [<Property>]
-        let ``SMap4 pairwise addition doesn't affect measure type `` (a: SMap4<NonEmptyString,NonEmptyString,NonEmptyString,NonEmptyString,Scalar<Item>>) (b: SMap4<NonEmptyString,NonEmptyString,NonEmptyString,NonEmptyString,Scalar<Item>>) =
-          // just make sure it compiles (was buggy giving SMap<NonEmptyString, Scalar<Item ^ 2>> due to implementation issue)
+        let ``SMap4 pairwise addition doesn't affect measure type `` (a: List<(NonEmptyString*NonEmptyString*NonEmptyString*NonEmptyString)*Scalar<Item>>) (b: List<(NonEmptyString*NonEmptyString*NonEmptyString*NonEmptyString)*Scalar<Item>>) =
+          let a = SMap4.ofList a
+          let b = SMap4.ofList b
           let c : SMap4<NonEmptyString,NonEmptyString,NonEmptyString,NonEmptyString, Scalar<Item>> = a + b
           ()
         [<Property>]
-        let ``SMap5 pairwise addition doesn't affect measure type `` (a: SMap5<NonEmptyString,NonEmptyString,NonEmptyString,NonEmptyString,NonEmptyString,Scalar<Item>>) (b: SMap5<NonEmptyString,NonEmptyString,NonEmptyString,NonEmptyString,NonEmptyString,Scalar<Item>>) =
-          // just make sure it compiles (was buggy giving SMap<NonEmptyString, Scalar<Item ^ 2>> due to implementation issue)
+        let ``SMap5 pairwise addition doesn't affect measure type `` (a: List<(NonEmptyString*NonEmptyString*NonEmptyString*NonEmptyString*NonEmptyString)*Scalar<Item>>) (b: List<(NonEmptyString*NonEmptyString*NonEmptyString*NonEmptyString*NonEmptyString)*Scalar<Item>>) =
+          let a = SMap5.ofList a
+          let b = SMap5.ofList b
           let c : SMap5<NonEmptyString,NonEmptyString,NonEmptyString,NonEmptyString,NonEmptyString, Scalar<Item>> = a + b
           ()
           

--- a/Flips.Tests/UnitsOfMeasure.Tests.fs
+++ b/Flips.Tests/UnitsOfMeasure.Tests.fs
@@ -10,8 +10,10 @@ open Flips.Tests.Types
 
 
 module UnitsOfMeasureTests =
+    open Flips.SliceMap
     open Flips.UnitsOfMeasure
     open Flips.UnitsOfMeasure.Types
+    open Flips.Tests.UnitsOfMeasure
     open Flips.Tests.Gens.UnitsOfMeasure
 
     let randomItemExpressionFromDecisions rng (decisions:seq<Decision<Item>>) =
@@ -207,3 +209,29 @@ module UnitsOfMeasureTests =
             Assert.Equal(expr, r)
 
 
+        // just make sure it compiles (was buggy giving SMap<NonEmptyString, Scalar<Item ^ 2>> due to implementation issue, same for SMap2, SMap3, SMap4 and SMap5)
+        [<Property>]
+        let ``SMap pairwise addition doesn't affect measure type `` (a: SMap<NonEmptyString,Scalar<Item>>) (b: SMap<NonEmptyString,Scalar<Item>>) =
+          let c : SMap<NonEmptyString, Scalar<Item>> = a + b
+          ()
+        [<Property>]
+        let ``SMap2 pairwise addition doesn't affect measure type `` (a: SMap2<NonEmptyString,NonEmptyString,Scalar<Item>>) (b: SMap2<NonEmptyString,NonEmptyString,Scalar<Item>>) =
+          // just make sure it compiles (was buggy giving SMap<NonEmptyString, Scalar<Item ^ 2>> due to implementation issue)
+          let c : SMap2<NonEmptyString, NonEmptyString, Scalar<Item>> = a + b
+          ()
+        [<Property>]
+        let ``SMap3 pairwise addition doesn't affect measure type `` (a: SMap3<NonEmptyString,NonEmptyString,NonEmptyString,Scalar<Item>>) (b: SMap3<NonEmptyString,NonEmptyString,NonEmptyString,Scalar<Item>>) =
+          // just make sure it compiles (was buggy giving SMap<NonEmptyString, Scalar<Item ^ 2>> due to implementation issue)
+          let c : SMap3<NonEmptyString,NonEmptyString,NonEmptyString, Scalar<Item>> = a + b
+          ()
+        [<Property>]
+        let ``SMap4 pairwise addition doesn't affect measure type `` (a: SMap4<NonEmptyString,NonEmptyString,NonEmptyString,NonEmptyString,Scalar<Item>>) (b: SMap4<NonEmptyString,NonEmptyString,NonEmptyString,NonEmptyString,Scalar<Item>>) =
+          // just make sure it compiles (was buggy giving SMap<NonEmptyString, Scalar<Item ^ 2>> due to implementation issue)
+          let c : SMap4<NonEmptyString,NonEmptyString,NonEmptyString,NonEmptyString, Scalar<Item>> = a + b
+          ()
+        [<Property>]
+        let ``SMap5 pairwise addition doesn't affect measure type `` (a: SMap5<NonEmptyString,NonEmptyString,NonEmptyString,NonEmptyString,NonEmptyString,Scalar<Item>>) (b: SMap5<NonEmptyString,NonEmptyString,NonEmptyString,NonEmptyString,NonEmptyString,Scalar<Item>>) =
+          // just make sure it compiles (was buggy giving SMap<NonEmptyString, Scalar<Item ^ 2>> due to implementation issue)
+          let c : SMap5<NonEmptyString,NonEmptyString,NonEmptyString,NonEmptyString,NonEmptyString, Scalar<Item>> = a + b
+          ()
+          

--- a/Flips/SMap.fs
+++ b/Flips/SMap.fs
@@ -98,7 +98,7 @@ type SMap<'Key, 'Value when 'Key : comparison and 'Value : equality>
         let newKeys = SliceSet.union a.Keys b.Keys
         let newTryFind k =
             match (a.TryFind k), (b.TryFind k) with
-            | Some lv, Some rv -> Some (lv * rv)
+            | Some lv, Some rv -> Some (lv + rv)
             | Some lv, None -> Some lv
             | None, Some rv -> Some rv
             | None, None -> None

--- a/Flips/SMap2.fs
+++ b/Flips/SMap2.fs
@@ -143,7 +143,7 @@ type SMap2<'Key1, 'Key2, 'Value when 'Key1 : comparison and 'Key2 : comparison a
         let newKeys2 = a.Keys2 + b.Keys2
         let newTryFind k =
             match (a.TryFind k), (b.TryFind k) with
-            | Some lv, Some rv -> Some (lv * rv)
+            | Some lv, Some rv -> Some (lv + rv)
             | Some lv, None -> Some lv
             | None, Some rv -> Some rv
             | None, None -> None

--- a/Flips/SMap3.fs
+++ b/Flips/SMap3.fs
@@ -196,7 +196,7 @@ type SMap3<'Key1, 'Key2, 'Key3, 'Value when 'Key1 : comparison and 'Key2 : compa
         let keys3 = a.Keys3 + b.Keys3
         let newTryFind k =
             match (a.TryFind k), (b.TryFind k) with
-            | Some lv, Some rv -> Some (lv * rv)
+            | Some lv, Some rv -> Some (lv + rv)
             | Some lv, None -> Some lv
             | None, Some rv -> Some rv
             | None, None -> None

--- a/Flips/SMap4.fs
+++ b/Flips/SMap4.fs
@@ -290,7 +290,7 @@ type SMap4<'Key1, 'Key2, 'Key3, 'Key4, 'Value when 'Key1 : comparison and 'Key2 
         let keys4 = a.Keys4 + b.Keys4
         let newTryFind k =
             match (a.TryFind k), (b.TryFind k) with
-            | Some lv, Some rv -> Some (lv * rv)
+            | Some lv, Some rv -> Some (lv + rv)
             | Some lv, None -> Some lv
             | None, Some rv -> Some rv
             | None, None -> None

--- a/Flips/SMap5.fs
+++ b/Flips/SMap5.fs
@@ -427,7 +427,7 @@ type SMap5<'Key1, 'Key2, 'Key3, 'Key4, 'Key5, 'Value when 'Key1 : comparison and
         let keys5 = a.Keys5 + b.Keys5
         let newTryFind k =
             match (a.TryFind k), (b.TryFind k) with
-            | Some lv, Some rv -> Some (lv * rv)
+            | Some lv, Some rv -> Some (lv + rv)
             | Some lv, None -> Some lv
             | None, Some rv -> Some rv
             | None, None -> None


### PR DESCRIPTION
```fsharp
let a = SMap.ofList [for i in 3..5 -> i,i]
let b = SMap.ofList [for i in 3..5 -> i,i]
let c = a + b
// SMap map [(3, 9); (4, 16); (5, 25)]
```

usage of units of measure would highlight it:
```fsharp
let a = SMap.ofList [for i in 3..5 -> i,float i * 1.<Item>]
let b = SMap.ofList [for i in 3..5 -> i,float i * 1.<Item>]
let c = a + b // error FS0001: The unit of measure 'Item' does not match the unit of measure 'Item ^ 2'
```

add one test over SMap + one that checks the result of pairwise addition keeps unit of measure unchanged on the lhs