### PR TITLE
Add option to write MPS file similar to the LP file.

### DIFF
--- a/Flips.Examples/BinaryProgrammingExample/BinaryProgrammingExample.fs
+++ b/Flips.Examples/BinaryProgrammingExample/BinaryProgrammingExample.fs
@@ -5,7 +5,7 @@ open Flips.Types
 open Flips.SliceMap
 
 
-let solve () =
+let solve settings =
 
     let indexes = [1..9]
     let value = [for i in indexes -> i, 10.0 - (float i)] |> SMap.ofList
@@ -23,13 +23,7 @@ let solve () =
     let model =
         Model.create objective
         |> Model.addConstraint uniqueConstraint
-
-    let settings = {
-        SolverType = SolverType.CBC
-        MaxDuration = 30_000L
-        WriteLPFile = Some "ConstraintBuilderExample.lp"
-    }
-    
+            
     let result = Solver.solve settings model
 
     printfn "--Result--"

--- a/Flips.Examples/CoffeeRoastingExample/CoffeeRoastingExample.fs
+++ b/Flips.Examples/CoffeeRoastingExample/CoffeeRoastingExample.fs
@@ -12,7 +12,7 @@ type [<Measure>] Build
 
 type Location = Location of string
 
-let solve () =
+let solve settings =
 
     let minRoastingCapacity = 30.0<Ton>
     let minWarehouseCapacity = 30_000.0<ft^3>
@@ -112,12 +112,6 @@ let solve () =
         |> Model.addConstraint minRoastingCapacityConstraint
         |> Model.addConstraint minWarehouseCapacityConstraint
         |> Model.addConstraints warehouseWithRoasterConstraints
-
-    let settings = {
-        SolverType = SolverType.CBC
-        MaxDuration = 10_000L
-        WriteLPFile = None
-    }
 
     // Call the `solve` function in the Solve module to evaluate the model
     let result = Solver.solve settings model

--- a/Flips.Examples/FoodTruckConstraintBuilderExample/FoodTruckConstraintBuilderExample.fs
+++ b/Flips.Examples/FoodTruckConstraintBuilderExample/FoodTruckConstraintBuilderExample.fs
@@ -3,7 +3,7 @@
 open Flips
 open Flips.Types
 
-let solve () =
+let solve settings =
 
     // Declare the parameters for our model
     let items = ["Hamburger"; "HotDog"]
@@ -43,14 +43,6 @@ let solve () =
         Model.create objective
         |> Model.addConstraints maxItemConstraints
         |> Model.addConstraint maxWeight
-
-    // Create a Settings type which tells the Solver which types of underlying solver to use,
-    // the time alloted for solving, and whether to write an LP file to disk
-    let settings = {
-        SolverType = SolverType.CBC
-        MaxDuration = 10_000L
-        WriteLPFile = None
-    }
 
     // Call the `solve` function in the Solve module to evaluate the model
     let result = Solver.solve settings model

--- a/Flips.Examples/FoodTruckDecisionBuilder/FoodTruckDecisionBuilder.fs
+++ b/Flips.Examples/FoodTruckDecisionBuilder/FoodTruckDecisionBuilder.fs
@@ -4,7 +4,7 @@
 open Flips
 open Flips.Types
 
-let solve () =
+let solve settings =
 
     // Declare the parameters for our model
     let items = ["Hamburger"; "HotDog"]
@@ -45,14 +45,6 @@ let solve () =
         Model.create objective
         |> Model.addConstraints maxItemConstraints
         |> Model.addConstraint maxWeight
-
-    // Create a Settings type which tells the Solver which types of underlying solver to use,
-    // the time alloted for solving, and whether to write an LP file to disk
-    let settings = {
-        SolverType = SolverType.CBC
-        MaxDuration = 10_000L
-        WriteLPFile = None
-    }
 
     // Call the `solve` function in the Solve module to evaluate the model
     let result = Solver.solve settings model

--- a/Flips.Examples/FoodTruckExample/FoodTruckExample.fs
+++ b/Flips.Examples/FoodTruckExample/FoodTruckExample.fs
@@ -4,7 +4,7 @@ open Flips
 open Flips.Types
 
 
-let solve () =
+let solve settings =
 
     // Declare the parameters for our model
     let hamburgerProfit = 1.50
@@ -39,14 +39,6 @@ let solve () =
         |> Model.addConstraint maxHamburger
         |> Model.addConstraint maxHotDog
         |> Model.addConstraint maxWeight
-
-    // Create a Settings type which tells the Solver which types of underlying solver to use,
-    // the time alloted for solving, and whether to write an LP file to disk
-    let settings = {
-        SolverType = SolverType.CBC
-        MaxDuration = 10_000L
-        WriteLPFile = None
-    }
 
     // Call the `solve` function in the Solve module to evaluate the model
     let result = Solver.solve settings model

--- a/Flips.Examples/FoodTruckMapExample/FoodTruckMapExample.fs
+++ b/Flips.Examples/FoodTruckMapExample/FoodTruckMapExample.fs
@@ -3,7 +3,7 @@
 open Flips
 open Flips.Types
 
-let solve () =
+let solve settings =
 
     // Declare the parameters for our model
     let items = ["Hamburger"; "HotDog"]
@@ -40,14 +40,6 @@ let solve () =
         Model.create objective
         |> Model.addConstraints maxItemConstraints
         |> Model.addConstraint maxWeight
-
-    // Create a Settings type which tells the Solver which types of underlying solver to use,
-    // the time alloted for solving, and whether to write an LP file to disk
-    let settings = {
-        SolverType = SolverType.CBC
-        MaxDuration = 10_000L
-        WriteLPFile = None
-    }
 
     // Call the `solve` function in the Solve module to evaluate the model
     let result = Solver.solve settings model

--- a/Flips.Examples/FoodTruckUnitsOfMeasureExample/FoodTruckUnitsOfMeasureExample.fs
+++ b/Flips.Examples/FoodTruckUnitsOfMeasureExample/FoodTruckUnitsOfMeasureExample.fs
@@ -8,7 +8,7 @@ type [<Measure>] USD
 type [<Measure>] Item
 type [<Measure>] Lb
 
-let solve () =
+let solve settings =
 
     // Declare the parameters for our model
     // This time include Units of Measure on the floats
@@ -51,14 +51,6 @@ let solve () =
         Model.create objective
         |> Model.addConstraints maxItemConstraints
         |> Model.addConstraint maxWeight
-
-    // Create a Settings type which tells the Solver which types of underlying solver to use,
-    // the time alloted for solving, and whether to write an LP file to disk
-    let settings = {
-        SolverType = SolverType.CBC
-        MaxDuration = 10_000L
-        WriteLPFile = None
-    }
 
     // Call the `solve` function in the Solve module to evaluate the model
     let result = Solver.solve settings model

--- a/Flips.Examples/MapSlicingExample/MapSlicingExample.fs
+++ b/Flips.Examples/MapSlicingExample/MapSlicingExample.fs
@@ -5,7 +5,7 @@ open Flips.Types
 open Flips.SliceMap
 
 
-let solve () =
+let solve settings =
     let sources = [1 .. 3]
     let sourceMax = Map.ofList [for s in sources -> s, 10.0 * float s]
 
@@ -68,12 +68,6 @@ let solve () =
         |> Model.addConstraints sourceConstraints
         |> Model.addConstraints destinationConstraints
         |> Model.addConstraints arcConstraints
-
-    let settings = {
-        SolverType = SolverType.CBC
-        MaxDuration = 30_000L
-        WriteLPFile = Some "ConstraintBuilderExample.lp"
-    }
 
     let result = Solver.solve settings model
 

--- a/Flips.Examples/MultiObjective/MultiObjectiveExample.fs
+++ b/Flips.Examples/MultiObjective/MultiObjectiveExample.fs
@@ -7,7 +7,7 @@ open Flips.SliceMap
 type Job = Job of int
 type Machine = Machine of int
 
-let solve () =
+let solve settings =
     let rng = System.Random(123)
     // Declare the parameters for our model
     let maxAssignments = 5.0
@@ -68,15 +68,6 @@ let solve () =
         |> Model.addConstraint assignmentConstraint
         |> Model.addConstraints machineAssignmentConstraints
         |> Model.addConstraints oneAssignmentConstraints
-
-
-    // Create a Settings type which tells the Solver which types of underlying solver to use,
-    // the time alloted for solving, and whether to write an LP file to disk
-    let settings = {
-        SolverType = SolverType.CBC
-        MaxDuration = 10_000L
-        WriteLPFile = None
-    }
 
     // Call the `solve` function in the Solve module to evaluate the model
     let result = Solver.solve settings model

--- a/Flips.Examples/MultipleFoodTrackExample/MultipleFoodTruckExample.fs
+++ b/Flips.Examples/MultipleFoodTrackExample/MultipleFoodTruckExample.fs
@@ -3,7 +3,7 @@
 open Flips
 open Flips.Types
 
-let solve () =
+let solve settings =
     
     // Declare the parameters for our model
     let items = ["Hamburger"; "HotDog"; "Pizza"]
@@ -65,14 +65,6 @@ let solve () =
         Model.create objective
         |> Model.addConstraints maxItemConstraints
         |> Model.addConstraints maxWeightConstraints
-
-    // Create a Settings type which tells the Solver which types of underlying solver to use,
-    // the time alloted for solving, and whether to write an LP file to disk
-    let settings = {
-        SolverType = SolverType.CBC
-        MaxDuration = 10_000L
-        WriteLPFile = None
-    }
 
     // Call the `solve` function in the Solve module to evaluate the model
     let result = Solver.solve settings model

--- a/Flips.Examples/MultipleFoodTruckSliceMapExample/MultipleFoodTruckSliceMapExample.fs
+++ b/Flips.Examples/MultipleFoodTruckSliceMapExample/MultipleFoodTruckSliceMapExample.fs
@@ -4,7 +4,7 @@ open Flips
 open Flips.Types
 open Flips.SliceMap
 
-let solve () =
+let solve settings =
     
     // Declare the parameters for our model
     let items = ["Hamburger"; "HotDog"; "Pizza"]
@@ -61,14 +61,6 @@ let solve () =
         Model.create objective
         |> Model.addConstraints maxItemConstraints
         |> Model.addConstraints maxWeightConstraints
-
-    // Create a Settings type which tells the Solver which types of underlying solver to use,
-    // the time alloted for solving, and whether to write an LP file to disk
-    let settings = {
-        SolverType = SolverType.CBC
-        MaxDuration = 10_000L
-        WriteLPFile = None
-    }
 
     // Call the `solve` function in the Solve module to evaluate the model
     let result = Solver.solve settings model

--- a/Flips.Examples/MultipleFoodTruckSliceMapWithUnitsOfMeasureExample/MultipleFoodTruckSliceMapWithUnitsOfMeasureExample.fs
+++ b/Flips.Examples/MultipleFoodTruckSliceMapWithUnitsOfMeasureExample/MultipleFoodTruckSliceMapWithUnitsOfMeasureExample.fs
@@ -9,7 +9,7 @@ type [<Measure>] USD
 type [<Measure>] Item
 type [<Measure>] Lb
 
-let solve () =
+let solve settings =
     
     // Declare the parameters for our model
     let items = ["Hamburger"; "HotDog"; "Pizza"]
@@ -60,14 +60,6 @@ let solve () =
         Model.create objective
         |> Model.addConstraints maxItemConstraints
         |> Model.addConstraints maxWeightConstraints
-
-    // Create a Settings type which tells the Solver which types of underlying solver to use,
-    // the time alloted for solving, and whether to write an LP file to disk
-    let settings = {
-        SolverType = SolverType.CBC
-        MaxDuration = 10_000L
-        WriteLPFile = None
-    }
 
     // Call the `solve` function in the Solve module to evaluate the model
     let result = Solver.solve settings model

--- a/Flips.Examples/Program.fs
+++ b/Flips.Examples/Program.fs
@@ -1,26 +1,35 @@
 ﻿// Learn more about F# at http://fsharp.org
 
 open System
+open Flips.Types
 open Flips.Examples
  
 
 [<EntryPoint>]
 let main argv =
-    
-    FoodTruckExample.solve ()
-    FoodTruckMapExample.solve ()
-    FoodTruckConstraintBuilderExample.solve ()
-    FoodTruckDecisionBuilder.solve ()
-    FoodTruckUnitsOfMeasureExample.solve ()
-    MultipleFoodTruckExample.solve ()
-    MultipleFoodTruckWithSliceMapExample.solve ()
-    MultipleFoodTruckSliceMapWithUnitsOfMeasureExample.solve ()
-    SimpleExample.solve ()
-    MapSlicingExample.solve ()
-    BinaryProgrammingExample.solve ()
-    StocksExample.solve ()
-    CoffeeRoastingExample.solve ()
-    MultiObjective.solve()
+    // Create a Settings type which tells the Solver which types of underlying solver to use,
+    // the time alloted for solving, and whether to write an LP file to disk
+    let settings = {
+        SolverType = SolverType.CBC
+        MaxDuration = 10_000L
+        WriteLPFile = None
+        WriteMPSFile = None
+    }
+
+    FoodTruckExample.solve settings
+    FoodTruckMapExample.solve settings
+    FoodTruckConstraintBuilderExample.solve settings
+    FoodTruckDecisionBuilder.solve settings
+    FoodTruckUnitsOfMeasureExample.solve settings
+    MultipleFoodTruckExample.solve settings
+    MultipleFoodTruckWithSliceMapExample.solve settings
+    MultipleFoodTruckSliceMapWithUnitsOfMeasureExample.solve settings
+    SimpleExample.solve { settings with WriteLPFile = Some "simpleproblem.lp" }
+    MapSlicingExample.solve { settings with WriteLPFile = Some "ConstraintBuilder.lp" }
+    BinaryProgrammingExample.solve { settings with WriteLPFile = Some "ConstraintBuilderWithBinary.lp" }
+    StocksExample.solve settings
+    CoffeeRoastingExample.solve settings
+    MultiObjective.solve { settings with WriteMPSFile = Some "multiobjective.mps" }
     printfn "Press any key to close..."
     Console.ReadKey () |> ignore
     0 // return an integer exit code

--- a/Flips.Examples/SimpleExample/SimpleExample.fs
+++ b/Flips.Examples/SimpleExample/SimpleExample.fs
@@ -3,7 +3,7 @@
 open Flips
 open Flips.Types
 
-let solve () =
+let solve settings =
     let x1 = Decision.createContinuous "x1" 0.0 infinity
     let x2 = Decision.createContinuous "x2" 0.0 infinity
     
@@ -14,12 +14,6 @@ let solve () =
         |> Model.addConstraint (Constraint.create "Max x1" (x1 <== 10.0))
         |> Model.addConstraint (Constraint.create "Max x2" (x2 <== 5.0))
         |> Model.addConstraint (Constraint.create "Max x1 and x2" (x1 + x2 <== 12.0))
-    
-    let settings = {
-        SolverType = SolverType.CBC
-        MaxDuration = 30_000L
-        WriteLPFile = Some "Test.lp"
-    }
     
     let result = Solver.solve settings model
     printfn "%A" result

--- a/Flips.Examples/StocksExample/StocksExample.fs
+++ b/Flips.Examples/StocksExample/StocksExample.fs
@@ -9,7 +9,7 @@ open Flips.Types
 
 type YahooStocks = CsvProvider<"2020-01-01,1.11,1.22,1.33,1.44,1.55,5666777888", Schema = " Date (date), Open (float), High(float), Low(float), Close(float), Adj Close (float), Volume(int64)">
 
-let solve () =
+let solve settings =
 
     // Raw data preparation (downloaded directly from yahoo using CSV data provider)
     let getStockReturns (tickers : string list) startDate endDate = 
@@ -93,14 +93,7 @@ let solve () =
         |> Model.addConstraint maxProfitConstraint
         |> Model.addConstraint maxWeightConstraint
         |> Model.addConstraints weightsLessThan1Constraints
-        
-    // Settings
-    let settings = {
-        SolverType = SolverType.CBC
-        MaxDuration = 1_000_000L
-        WriteLPFile = None
-    }
-
+    
     // Solve
     let results = Solver.solve settings model
 

--- a/Flips.Tests/Tests.fs
+++ b/Flips.Tests/Tests.fs
@@ -236,6 +236,7 @@ module Types =
                 SolverType = SolverType.CBC
                 MaxDuration = 30_000L
                 WriteLPFile = Some "Test.lp"
+                WriteMPSFile = Some "Test.mps"
             }
         
             let result = Solver.solve settings model
@@ -333,6 +334,7 @@ module Types =
                 SolverType = SolverType.CBC
                 MaxDuration = 10_000L
                 WriteLPFile = None
+                WriteMPSFile = None
             }
 
             // Call the `solve` function in the Solve module to evaluate the model

--- a/Flips/Types.fs
+++ b/Flips/Types.fs
@@ -419,6 +419,7 @@ type SolverSettings = {
     SolverType : SolverType
     MaxDuration : int64
     WriteLPFile : Option<string>
+    WriteMPSFile : Option<string>
 }
 
 /// The result of calling the solve function. If the solve was successful, the Optimal

--- a/docs/example-problems/coffee-planning.md
+++ b/docs/example-problems/coffee-planning.md
@@ -116,6 +116,7 @@ let settings = {
     SolverType = SolverType.CBC
     MaxDuration = 10_000L
     WriteLPFile = None
+    WriteMPSFile = None
 }
 
 // Call the `solve` function in the Solve module to evaluate the model

--- a/docs/example-problems/food-truck-constraint-builder.md
+++ b/docs/example-problems/food-truck-constraint-builder.md
@@ -51,6 +51,7 @@ let settings = {
     SolverType = SolverType.CBC
     MaxDuration = 10_000L
     WriteLPFile = None
+    WriteMPSFile = None
 }
 
 // Call the `solve` function in the Solve module to evaluate the model

--- a/docs/example-problems/food-truck-decision-builder.md
+++ b/docs/example-problems/food-truck-decision-builder.md
@@ -52,6 +52,7 @@ let settings = {
     SolverType = SolverType.CBC
     MaxDuration = 10_000L
     WriteLPFile = None
+    WriteMPSFile = None
 }
 
 // Call the `solve` function in the Solve module to evaluate the model

--- a/docs/example-problems/food-truck-intro-problem.md
+++ b/docs/example-problems/food-truck-intro-problem.md
@@ -46,6 +46,7 @@ let settings = {
     SolverType = SolverType.CBC
     MaxDuration = 10_000L
     WriteLPFile = None
+    WriteMPSFile = None
 }
 
 // Call the `solve` function in the Solve module to evaluate the model

--- a/docs/example-problems/food-truck-using-map.md
+++ b/docs/example-problems/food-truck-using-map.md
@@ -48,6 +48,7 @@ let settings = {
     SolverType = SolverType.CBC
     MaxDuration = 10_000L
     WriteLPFile = None
+    WriteMPSFile = None
 }
 
 // Call the `solve` function in the Solve module to evaluate the model


### PR DESCRIPTION
Refactor the samples so only one settings template is passed around to minimize places that need to change when Settings record evolves.

We should consider having `Settings.ofSolverType` or similar API that gives good default so client code isn't forced to initialize the full record but only alter the relevant properties.