### PR TITLE
few additions to cplex solver to cover their options and callbacks APIs

### DIFF
--- a/Flips.Solver.Cplex/CplexSolver.fs
+++ b/Flips.Solver.Cplex/CplexSolver.fs
@@ -10,8 +10,10 @@ open ILOG.CPLEX
 open ILOG.Concert
 
 module rec CplexSolver =
+    open System
         
     module Primitives =
+
         type Vars = IReadOnlyDictionary<DecisionName, INumVar>
 
         let setVariable  ({Type = decisionType; Name = DecisionName name }) (var:INumVar) =
@@ -89,80 +91,148 @@ module rec CplexSolver =
                         if state.ofCplexContext.unknownDecisionTurnsToZero then
                             d, 0.
                         else
-                            raise (Exception(sprintf "Decision %A was somehow not setup" d.Name))
+                            raise (System.Exception(sprintf "Decision %A was somehow not setup" d.Name))
                 )
                 |> Map.ofSeq
             {|
                 DecisionResults = decisionMap
-                ObjectiveResult = Flips.Types.LinearExpression.Evaluate decisionMap objective.Expression
+                ObjectiveValue = Flips.Types.LinearExpression.Evaluate decisionMap objective.Expression
             |}
 
-        let solve (model: Flips.Model.Model) state =
-            let decisionsByName = 
-                [
-                    for c in model.Constraints do
-                        yield! c.Expression.GetDecisions()
-                    for o in model.Objectives do
-                        yield! o.Expression.GetDecisions()
-                ]
-                |> HashSet
-                |> Seq.map (fun d -> d.Name, d)
-                |> readOnlyDict
-            
-            let vars =
-                match state.problem.flipsDecisionToCplexNumVar with
-                | :? Dictionary<_,_> as d -> d
-                | :? IReadOnlyDictionary<_,_> as d ->
-                    let d =
-                        [for (KeyValue(k,v)) in d -> k,v]
-                        |> dict 
-                        |> Dictionary
-                    state.problem <- {state.problem with flipsDecisionToCplexNumVar = d }
+        let runSolverWithCallbacks (model: Flips.Types.Model) state (callbackHandler: Cplex.Callback array) =
+          state.cplex.ClearCallbacks()
+          if not (isNull callbackHandler) then
+            for callback in callbackHandler do
+              if not (isNull callback) then
+                state.cplex.Use callback
+          let decisionsByName = 
+              [
+                  for d in model.GetDecisions() do
                     d
-                | _ ->
-                    let d = Dictionary<_,_>()
-                    state.problem <- {state.problem with flipsDecisionToCplexNumVar = d }
-                    d
+              ]
+              |> HashSet
+              |> Seq.map (fun d -> d.Name, d)
+              |> readOnlyDict
 
-            for KeyValue(name,decision) in decisionsByName do
+          let vars =
+              match state.problem.flipsDecisionToCplexNumVar with
+              | :? Dictionary<_,_> as d -> d
+              | :? IReadOnlyDictionary<_,_> as d ->
+                  let d =
+                      [for (KeyValue(k,v)) in d -> k,v]
+                      |> dict 
+                      |> Dictionary
+                  state.problem <- {state.problem with flipsDecisionToCplexNumVar = d }
+                  d
+              | _ ->
+                  let d = Dictionary<_,_>()
+                  state.problem <- {state.problem with flipsDecisionToCplexNumVar = d }
+                  d
 
-                match vars.TryGetValue name with
-                | false, _ ->
-                    vars.[name] <- 
-                        let cplexVar = createVariable decision state
-                        state.cplex.Add cplexVar |> ignore
-                        
-                        cplexVar
-                | true, var ->
-                    
-                    if state.options.HasDoNotReuseState then
-                        failwithf "using the same solver more than once is not an option"
-                    else
-                        printfn "variable %A already exists, removing before re-adding" name
-                        setVariable decision var
-                
-            let cx = addConstraints vars model.Constraints state
-            let objective = model.Objectives.Head
-            let _ = addObjective vars objective state
+          for KeyValue(name,decision) in decisionsByName do
+              match vars.TryGetValue name with
+              | false, _ ->
+                  vars.[name] <- 
+                      let cplexVar = createVariable decision state
+                      state.cplex.Add cplexVar |> ignore
+                      cplexVar
+              | true, var ->
+                  if state.options.HasDoNotReuseState then
+                      failwithf "using the same solver more than once is not an option"
+                  else
+                      printfn "variable %A already exists, removing before re-adding" name
+                      setVariable decision var
 
-            // look for WriteToFile option
-            state.options.ExportToFiles 
-            |> Seq.iter(state.cplex.ExportModel)
-            
-            if state.cplex.Solve() then
-                let solution = buildSolution decisionsByName.Values vars state objective
-                Ok solution
-            else
-                Error ""
+          let cx = addConstraints vars model.Constraints state
+          let objective = model.Objectives.Head
 
+          let _ = addObjective vars objective state
 
+          // look for WriteToFile option
+          state.options.ExportToFiles 
+          |> Seq.iter(state.cplex.ExportModel)
+
+          use __ = 
+            { new IDisposable with 
+              member x.Dispose () =
+                state.cplex.ClearCallbacks()
+            } 
+
+          if state.cplex.Solve() then
+              let solution = buildSolution decisionsByName.Values vars state objective
+              Ok solution
+          else
+              Error ""
+
+          
+        let runSolverWithCallback (model: Flips.Types.Model) state (callbackHandler: Cplex.Callback) =
+            runSolverWithCallbacks model state [|callbackHandler|]
+
+        let solve (model: Flips.Types.Model) state = runSolverWithCallback model state null
+  
     type ICPlexOption =
         inherit System.IComparable
-        
+
+    [<CustomEquality;CustomComparison>]
+    type NativeParam = 
+      | NativeParam of param: ILOG.CPLEX.Cplex.Param
+      override x.GetHashCode () =
+        let (NativeParam p) = x 
+        p.GetType().Name.GetHashCode() ^^^ p.GetValue()
+      override x.Equals other =
+        (x :> IComparable).CompareTo(other) = 0
+      interface IComparable with
+        member x.CompareTo other =
+          if isNull other then
+            1
+          else
+            match other with
+            | :? NativeParam as other ->
+              match other with
+              | NativeParam other -> 
+                let (NativeParam x) = x
+                let nameCompare = x.GetType().Name.CompareTo (other.GetType().Name)
+                if nameCompare = 0 then
+                  x.GetValue().CompareTo( other.GetValue())
+                else
+                  nameCompare
+            | _ -> 1
+          
     type CplexOption =
         | DoNotReuseState
         | WriteToFile of fileName: string
-        interface ICPlexOption
+        | CplexIntOption of Cplex.IntParam * value: int
+        | CplexLongOption of Cplex.LongParam * value: int64
+        | CplexBoolOption of Cplex.BooleanParam * value: bool
+        | CplexDoubleOption of Cplex.DoubleParam * value: float
+        | CplexStringOption of Cplex.StringParam * value: string
+        
+        member x.CompareTo (other: obj) = 
+          if isNull other then 1 else
+          match other with
+          | :? CplexOption as other ->
+            match other, x with
+            | CplexIntOption(p,v), CplexIntOption(p2,v2) ->
+              if p = p2 then v2.CompareTo v
+              else p2.GetType().Name.CompareTo (p.GetType().Name)
+            | CplexBoolOption(p,v), CplexBoolOption(p2,v2) ->
+              if p = p2 then v2.CompareTo v
+              else p2.GetType().Name.CompareTo (p.GetType().Name)
+            | CplexDoubleOption(p,v), CplexDoubleOption(p2,v2) ->
+              if p = p2 then v2.CompareTo v
+              else p2.GetType().Name.CompareTo (p.GetType().Name)
+            | CplexStringOption(p,v), CplexStringOption(p2,v2) ->
+              if p = p2 then v2.CompareTo v
+              else p2.GetType().Name.CompareTo (p.GetType().Name)
+            | CplexLongOption(p,v), CplexLongOption(p2,v2) ->
+              if p = p2 then v2.CompareTo v
+              else p2.GetType().Name.CompareTo (p.GetType().Name)
+            | _ -> 1
+          | _ -> 1
+
+        interface ICPlexOption with
+          member x.CompareTo other =  x.CompareTo other
+
 
     type CplexOptions =
         {
@@ -176,6 +246,16 @@ module rec CplexSolver =
             |> Seq.choose (function WriteToFile file -> Some file | _ -> None)
             |> Seq.toArray
 
+    type ICplexRunningSolverState = 
+      internal {
+        solverState: ICplexSolverState
+        task: System.Threading.Tasks.Task
+      }
+
+    type State = 
+      static member ofCplex (cplex: Cplex) = ICplexSolverState.createWithCplex cplex
+      static member getCplex state         = state.cplex
+
     type ICplexSolverState =
         internal {
             cplex: Cplex
@@ -185,17 +265,77 @@ module rec CplexSolver =
             options       : CplexOptions
         }
 
-        static member create () =
-            { cplex          = new Cplex()
-              problem        = createEmpty()
-              lock           = obj()
-              ofCplexContext = { unknownDecisionTurnsToZero = true }
-              options        = {options =  Set.ofList [DoNotReuseState] }
-            }
+        member x.TryGetNumVar decisionName = x.problem.flipsDecisionToCplexNumVar.TryGetValue decisionName
+        member x.TryGetConstraint constraintName = x.problem.flipsConstraintToCplexExpr.TryGetValue constraintName
+        
+        static member createWithCplex cplex =
+          let event = new Event<_>()
+          {
+            cplex          = cplex
+            problem        = createEmpty()
+            lock           = obj()
+            ofCplexContext = { unknownDecisionTurnsToZero = true }
+            options        = {options =  Set.ofList [DoNotReuseState] }
+          }
+        
+        static member create () = ICplexSolverState.createWithCplex(new Cplex())
+              
 
         static member setOption cplexOption (state: ICplexSolverState) = 
             { state with options = { state.options with options = Set.add cplexOption state.options.options } }
 
+        static member setCplexStringOption (value: string) (param: ILOG.CPLEX.Cplex.StringParam) (state: ICplexSolverState) = 
+            state.cplex.SetParam(param, value)
+            let option : ICPlexOption = CplexStringOption(param, value) :> _
+            ICplexSolverState.setOption option state
+        static member setCplexIntOption (param: ILOG.CPLEX.Cplex.IntParam) (value: int)  (state: ICplexSolverState) = 
+            state.cplex.SetParam(param, value)
+            let option : ICPlexOption = CplexIntOption(param, value) :> _
+            ICplexSolverState.setOption option state
+        static member setCplexLongOption (param: ILOG.CPLEX.Cplex.LongParam) (value: int64) (state: ICplexSolverState) = 
+            state.cplex.SetParam(param, value)
+            let option : ICPlexOption = CplexLongOption(param, value) :> _
+            ICplexSolverState.setOption option state
+        static member setCplexDoubleOption (param: ILOG.CPLEX.Cplex.DoubleParam) (value: float) (state: ICplexSolverState) = 
+            state.cplex.SetParam(param, value)
+            let option : ICPlexOption = CplexDoubleOption(param, value) :> _
+            ICplexSolverState.setOption option state
+        static member setCplexBoolOption (param: ILOG.CPLEX.Cplex.BooleanParam) (value: bool) (state: ICplexSolverState) = 
+            state.cplex.SetParam(param, value)
+            let option : ICPlexOption = CplexBoolOption(param, value) :> _
+            
+            ICplexSolverState.setOption option state
+
+        /// remark: use removeCplexOptions if many
+        static member removeCplexOption (o: ILOG.CPLEX.Cplex.Param) state =
+          let otherValue = o.GetValue()
+          let remaining = 
+            [|
+              for p in state.cplex.GetParameterSet() do
+                match p with
+                | :? ILOG.CPLEX.Cplex.Param as p ->
+                  if p.GetValue () = otherValue then
+                    ()
+                | p ->
+                  match p with
+                  | :? Cplex.IntParam as p     -> if p.GetValue() = otherValue then () else p :> Cplex.Param, box (state.cplex.GetParam(p))
+                  | :? Cplex.LongParam as p    -> if p.GetValue() = otherValue then () else p :> Cplex.Param, box (state.cplex.GetParam(p))
+                  | :? Cplex.StringParam as p  -> if p.GetValue() = otherValue then () else p :> Cplex.Param, box (state.cplex.GetParam(p))
+                  | :? Cplex.BooleanParam as p -> if p.GetValue() = otherValue then () else p :> Cplex.Param, box (state.cplex.GetParam(p))
+                  | :? Cplex.DoubleParam as p  -> if p.GetValue() = otherValue then () else p :> Cplex.Param, box (state.cplex.GetParam(p))
+                  | _ -> failwith $"can't get param value %A{p}"
+                  ()
+            |]
+          state.cplex.GetParameterSet().Clear()
+          for p,v in remaining do
+            match p with
+            | :? Cplex.IntParam as p     -> state.cplex.SetParam(p, unbox v)
+            | :? Cplex.LongParam as p    -> state.cplex.SetParam(p, unbox v)
+            | :? Cplex.StringParam as p  -> state.cplex.SetParam(p, unbox v)
+            | :? Cplex.BooleanParam as p -> state.cplex.SetParam(p, unbox v)
+            | :? Cplex.DoubleParam as p  -> state.cplex.SetParam(p, unbox v)
+            | _ -> failwith $"can't set param value %A{p}"
+          state
         static member removeOption (cplexOptionPredicate: CplexOption -> bool) state = 
             let newOptions =
                 [
@@ -204,9 +344,18 @@ module rec CplexSolver =
                         | :? CplexOption as i ->
                             if not (cplexOptionPredicate i) then
                                 i :> ICPlexOption
+                            else
+                              match i with
+                              | CplexIntOption(o,v) ->    failwith $"solver parameter can't be reset individually {o.GetType().Name}"
+                              | CplexDoubleOption(o,v) -> failwith $"solver parameter can't be reset individually {o.GetType().Name}"
+                              | CplexStringOption(o,v) -> failwith $"solver parameter can't be reset individually {o.GetType().Name}"
+                              | CplexLongOption(o,v) ->   failwith $"solver parameter can't be reset individually {o.GetType().Name}"
+                              | CplexBoolOption(o,v) ->   failwith $"solver parameter can't be reset individually {o.GetType().Name}"
+                              | _ -> ()
                         | _ -> ()
                 ] |> Set.ofList
             { state with options = { state.options with options = newOptions } }
+
 
     type CPlexProblemState = 
         {

--- a/Flips.Solver.Cplex/Flips.Types.TypeExtensions.fs
+++ b/Flips.Solver.Cplex/Flips.Types.TypeExtensions.fs
@@ -16,15 +16,61 @@ module Extensions =
           | ObjectiveSense.Maximize -> ILOG.Concert.ObjectiveSense.Maximize
           | ObjectiveSense.Minimize -> ILOG.Concert.ObjectiveSense.Minimize
 
-  type Flips.Types.DecisionName with
-      member x.AsString = match x with DecisionName n -> n
-namespace Flips.Types.TypeExtensions
 
+namespace Flips.Types.TypeExtensions
 
 open Flips.Types
 [<AutoOpen>]
 module rec Extensions =
+  type Flips.Types.Decision with 
+      member x.LB = 
+        match x with 
+        | {Type = DecisionType.Continuous(v,_) } 
+        | {Type = DecisionType.Integer(v,_) } -> v
+        | {Type = DecisionType.Boolean } -> 0.
+      member x.UB = 
+        match x with 
+        | {Type = DecisionType.Continuous(_,v) } 
+        | {Type = DecisionType.Integer(_,v) } -> v
+        | {Type = DecisionType.Boolean } -> 1.
+      member x.Bounds = x.LB,x.UB
 
+  type Flips.Types.Objective with
+      member x.Name = match x with | { Name = name } -> name
+
+  type Flips.Types.ObjectiveName with
+      member x.AsString = match x with ObjectiveName n -> n
+
+  type Flips.Types.ConstraintName with
+      member x.AsString = match x with ConstraintName n -> n
+
+  type Flips.Types.DecisionName with
+      member x.AsString = match x with DecisionName n -> n
+  let uom<[<Measure>]'measure> = LanguagePrimitives.FloatWithMeasure<'measure>
+
+  type Flips.UnitsOfMeasure.Types.Objective<[<Measure>]'m> with
+      member x.Objective =
+        match (x: Flips.UnitsOfMeasure.Types.Objective<'m>) with 
+        | Flips.UnitsOfMeasure.Types.Objective.Value o -> o
+    
+  type Flips.UnitsOfMeasure.Types.Decision<[<Measure>]'m> with
+    
+      member x.Decision =
+        match (x: Flips.UnitsOfMeasure.Types.Decision<'m>) with 
+        | Flips.UnitsOfMeasure.Types.Value x -> x
+
+      member x.LB = x.Decision.LB * (uom<'m> 1.)
+      member x.UB = x.Decision.UB * (uom<'m> 1.)
+
+  type Flips.Types.Objective with
+      static member getName       (x: Flips.Types.Objective) = match x with | { Name = n } -> n
+      static member getExpression (x: Flips.Types.Objective) = match x with | { Expression = e } -> e
+
+  type Flips.Types.Constraint with
+      static member getName       (x: Flips.Types.Constraint) = match x with | { Name = n } -> n
+      static member getExpression (x: Flips.Types.Constraint) = match x with | { Expression = e } -> e
+  type Flips.Types.LinearExpression with
+      static member evaluate valMap expr = Flips.Types.LinearExpression.Evaluate valMap expr
   type Flips.Types.Model with
       member x.GetDecisions() =
           seq {
@@ -44,16 +90,16 @@ module rec Extensions =
 
   /// todo for matthewcrews: review if correct and can go to Flips.Solver
   type Flips.Types.ConstraintExpression with
-      member internal x.LHS =
+      member x.LHS =
           match x with
           | ConstraintExpression.Inequality(LHS=lhs)
           | ConstraintExpression.Equality(LHS=lhs) -> lhs
-      member internal x.RHS =
+      member x.RHS =
           match x with
           | ConstraintExpression.Inequality(RHS=rhs)
           | ConstraintExpression.Equality(RHS=rhs) -> rhs
 
-      member internal x.GetDecisions () =
+      member x.GetDecisions () =
           seq {
               match x with
               | ConstraintExpression.Equality(lhs,rhs) 
@@ -61,3 +107,42 @@ module rec Extensions =
                   yield! lhs.GetDecisions()
                   yield! rhs.GetDecisions()            
           }
+
+  type Printer =
+    static member print (expr: Flips.Types.Objective) =
+      let t =
+        match expr.Sense with
+        | ObjectiveSense.Maximize -> "max"
+        | ObjectiveSense.Minimize -> "min"
+      $"{t} {expr.Name.AsString} such as: {Printer.print expr.Expression}"
+
+    static member print (expr: Flips.Types.Constraint) =
+      $"{expr.Name.AsString} : {Printer.print expr.Expression}"
+
+    static member print (expr: Flips.Types.ConstraintExpression) =
+      let op = 
+        match expr with
+        | Inequality(inequality=GreaterOrEqual) -> ">="
+        | Inequality(inequality=LessOrEqual) -> "<="
+        | Equality _ -> "="
+      match expr with
+      | Inequality(lhs,_ ,rhs)
+      | Equality (lhs, rhs) -> $"{Printer.print lhs} {op} {Printer.print rhs}"
+
+    static member print (expr: Flips.Types.LinearExpression) =
+      match expr with
+      | LinearExpression.Empty -> ""
+      | LinearExpression.AddDecision((1.,d),Empty) -> $"{d.Name.AsString}"
+      | LinearExpression.AddDecision((coef,d),Empty) -> $"(%f{coef} * {d.Name.AsString})"
+      | LinearExpression.AddDecision((1.,d),expr) -> $"{d.Name.AsString} + {Printer.print expr}"
+      | LinearExpression.AddDecision((coef,d),expr) -> $"%f{coef} * {d.Name.AsString} + {Printer.print expr}"
+      | LinearExpression.Multiply(coef,Empty) -> ""
+      | LinearExpression.Multiply(1.,expr) -> $"{Printer.print expr}"
+      | LinearExpression.Multiply(coef,expr) -> $"%f{coef} * ({Printer.print expr})"
+      | LinearExpression.AddFloat(k,Empty) -> $"%f{k}"
+      | LinearExpression.AddFloat(0.,expr) -> $"{expr}"
+      | LinearExpression.AddFloat(k,expr) -> $"%f{k} + ({expr})"
+      | LinearExpression.AddLinearExpression(l,Empty) -> $"{Printer.print l}"
+      | LinearExpression.AddLinearExpression(Empty,r) -> $"{Printer.print r}"
+      | LinearExpression.AddLinearExpression(l,r) -> $"{Printer.print l} + {Printer.print r}"
+      

--- a/Flips.sln
+++ b/Flips.sln
@@ -26,6 +26,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{C3221202-C
 		docs\package.json = docs\package.json
 		docs\README.md = docs\README.md
 		docs\WhatIsOptimization.md = docs\WhatIsOptimization.md
+		docs\solver-samples\cplex.fsx = docs\solver-samples\cplex.fsx
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "example-problems", "example-problems", "{4693BB0E-197B-4B9D-9B2B-F25E9FA939DA}"


### PR DESCRIPTION
Flips.Solver.Cplex: settings & callbacks (related to #103)

* set cplex settings value
* handling of cplex callback through cplex.Use (https://www-eio.upc.edu/lceio/manuals/cplex-11/html/refdotnetcplex/html/ILOG.CPLEX.Cplex.Use_overloads.html)

also fix stack overflow in own type extensions of Flips.Types.*.GetDecisions() by calling to `LinearExpression.Reduce`

with those changes, using `Flips.Solver.Cplex`:

setting an option on cplex solver "state" object:
```fsharp
open Flips.Solver.Cplex.Internals

let state =
    CplexSolver.ICplexSolverState.create()
    |> CplexSolver.ICplexSolverState.setCplexBoolOption ILOG.CPLEX.Cplex.BooleanParam.MemoryEmphasis true
```

getting the decisions without crashing on a "large" problem (10k decisions)
```fsharp
let model = Flips.Docs.Samples.sampleProblem()
model.GetDecisions() |> System.Collections.Generic.HashSet
```

callbacks:

they can be written as object expression implementing CPLEX API, although right now, they don't seem to trigger.
```fsharp
let callback = 
  { new ILOG.CPLEX.Cplex.SolveCallback() with
      member x.Main() = printfn "solving... current objective: %f" (x.GetObjValue()) }

CplexSolver.Primitives.runSolverWithCallback model state callback
```